### PR TITLE
Use the track color as the background color

### DIFF
--- a/inc/schedule-output-functions.php
+++ b/inc/schedule-output-functions.php
@@ -293,7 +293,8 @@ function wpcs_scheduleOutput( $props ) {
 			$track = get_term( $term_id, 'wpcs_track' );
 			
 				$html .= sprintf(
-				'<th class="wpcs-col-track"> <span class="wpcs-track-name">%s</span> <span class="wpcs-track-description">%s</span> </th>',
+				'<th class="wpcs-col-track" style="background-color:%s;"> <span class="wpcs-track-name">%s</span> <span class="wpcs-track-description">%s</span> </th>',
+				$trackColor = get_term_meta($term_id, 'track_color', true),
 				isset( $track->term_id ) ? esc_html( $track->name ) : '',
 				isset( $track->term_id ) ? esc_html( $track->description ) : ''
 			);


### PR DESCRIPTION
This PR uses the `track_color` term meta as the background color of the track column header.

## Visuals

![image](https://user-images.githubusercontent.com/10858303/200413495-de179bbc-670c-4dab-96aa-6b0f1e985e24.png)

![image](https://user-images.githubusercontent.com/10858303/200413707-4bd25408-a91d-423e-bc70-238028baa754.png)
